### PR TITLE
Fix for envelope routines:EVP_DecryptFinal_ex:bad decrypt

### DIFF
--- a/checksum/crypt.js
+++ b/checksum/crypt.js
@@ -47,6 +47,7 @@ var crypt = {
       break;
     }
     var decipher = crypto.createDecipheriv('AES-' + algo + '-CBC', key, iv);
+    decipher.setAutoPadding(false);
     var decrypted = decipher.update(data, 'base64', 'binary');
     try {
       decrypted += decipher.final('binary');


### PR DESCRIPTION
This error seems to occur while decrypt function is called. The problem is in padding. By default, node uses PKCS padding. So setting AutoPadding to false fixes the issue.

[Fix as here ](https://github.com/nodejs/node/issues/2794). 