### PR TITLE
Fixed a data type error

### DIFF
--- a/checksum/checksum.js
+++ b/checksum/checksum.js
@@ -11,16 +11,18 @@ function paramsToString(params, mandatoryflag) {
   var tempKeys = Object.keys(params);
   tempKeys.sort();
   tempKeys.forEach(function (key) {
-  var n = params[key].includes("REFUND"); 
-   var m = params[key].includes("|");  
-        if(n == true )
-        {
-          params[key] = "";
-        }
-          if(m == true)
-        {
-          params[key] = "";
-        }  
+    if (key !== 'ORDER_ID' && key !== 'CUST_ID' && key !== 'TXN_AMOUNT') {  
+      var n = params[key].includes("REFUND"); 
+      var m = params[key].includes("|");  
+          if(n == true )
+          {
+            params[key] = "";
+          }
+            if(m == true)
+          {
+            params[key] = "";
+          }  
+    }
     if (key !== 'CHECKSUMHASH' ) {
       if (params[key] === 'null') params[key] = '';
       if (!mandatoryflag || mandatoryParams.indexOf(key) !== -1) {


### PR DESCRIPTION
_Transaction Amount, Customer ID and Order ID_ may not be always of **string**  data type and it returned the following error while I was performing a test : - 
![image](https://user-images.githubusercontent.com/41195162/60722507-c1406880-9f4e-11e9-8b21-3de2e4b3708c.png)

The error did come from line 14 and 15 of the function **paramsToString**
So, I pushed that part (lines 14-23)  inside an **if block** and it fixed the error.
It is working fine now.